### PR TITLE
Fix for multiple parameters with the same name being dropped

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -548,16 +548,7 @@ class Client(httplib2.Http):
             DEFAULT_CONTENT_TYPE) != DEFAULT_CONTENT_TYPE
 
         if body and method == "POST" and not is_multipart:
-            param_tuples = parse_qsl(body)
-            parameters = {}
-            for key, value in param_tuples:
-                if key in parameters:
-                    if isinstance(parameters[key], list):
-                        parameters[key].append(value)
-                    else:
-                        parameters[key] = [parameters[key], value]
-                else:
-                    parameters[key] = value
+            parameters = parse_qs(body)
         else:
             parameters = None
 


### PR DESCRIPTION
Hi, I have implemented a fix for the following issue: http://github.com/simplegeo/python-oauth2/issues#issue/23
