### PR TITLE
sending callback url with client.request

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -544,7 +544,7 @@ class Client(httplib2.Http):
         self.method = method
 
     def request(self, uri, method="GET", body=None, headers=None, 
-        redirections=httplib2.DEFAULT_MAX_REDIRECTS, connection_type=None):
+        redirections=httplib2.DEFAULT_MAX_REDIRECTS, connection_type=None, call_back=None):
         DEFAULT_CONTENT_TYPE = 'application/x-www-form-urlencoded'
 
         if not isinstance(headers, dict):
@@ -555,6 +555,8 @@ class Client(httplib2.Http):
 
         if body and method == "POST" and not is_multipart:
             parameters = dict(parse_qsl(body))
+        elif method=='GET' and call_back!=None:
+            parameters={'oauth_callback':call_back}
         else:
             parameters = None
 


### PR DESCRIPTION
when I was working with identi.ca the request function did not worked for authorizing
they told to me in the new version of oauth standard I should send a url or (oob) with authorize requests.
so I have changed two lines of this module and my problem solved.
