### PR TITLE
Simple change that allows parameters to be passed in to Client.request()

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -637,7 +637,7 @@ class Client(httplib2.Http):
         self.method = method
 
     def request(self, uri, method="GET", body='', headers=None, 
-        redirections=httplib2.DEFAULT_MAX_REDIRECTS, connection_type=None, parameters={}):
+        redirections=httplib2.DEFAULT_MAX_REDIRECTS, connection_type=None, extra_parameters={}):
         DEFAULT_POST_CONTENT_TYPE = 'application/x-www-form-urlencoded'
 
         if not isinstance(headers, dict):
@@ -650,11 +650,13 @@ class Client(httplib2.Http):
         is_form_encoded = \
             headers.get('Content-Type') == 'application/x-www-form-urlencoded'
 
-        if not isinstance(parameters, dict):
+        if is_form_encoded and body:
+            parameters = parse_qs(body)
+        else:
             parameters = {}
 
-        if is_form_encoded and body:
-            parameters.update(parse_qs(body))
+        if extra_parameters and isinstance(extra_parameters, dict):
+            parameters.update(extra_parameters)
 
         req = Request.from_consumer_and_token(self.consumer, 
             token=self.token, http_method=method, http_url=uri, 


### PR DESCRIPTION
Essentially, the problem I was experiencing is that django-piston 0.3 forces the oauth_callback parameter to be sent on requesting a token, as is specified in the OAuth 1.0a specification.  However, in the sample Client code, there seemed to be no way to get this to work with the current python-oauth2 code.  If I passed oauth_callback parameters in via the body, django-piston would fail (could be a bug from django-piston).  So essentially, this change just adds a keyword argument parameters={}, which defaults to an empty dictionary, and is updated with parameters from the body if present.  This change, I believe is 2 lines of code total, and makes the client code much more extensible in terms of adding non-OAuth parameters as well in the workflow.
