### PR TITLE
Fix for import order for ticket #61 to fix running tests

### DIFF
--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -26,6 +26,7 @@ THE SOFTWARE.
 import sys
 import os
 import unittest
+sys.path[0:0] = [os.path.join(os.path.dirname(__file__), ".."),]
 import oauth2 as oauth
 import random
 import time
@@ -40,9 +41,6 @@ try:
     from urlparse import parse_qs, parse_qsl
 except ImportError:
     from cgi import parse_qs, parse_qsl
-
-
-sys.path[0:0] = [os.path.join(os.path.dirname(__file__), ".."),]
 
 
 class TestError(unittest.TestCase):


### PR DESCRIPTION
Moves the adding of the parent directory to the python path to above the import of oauth2 module.

Means tests can be run against the module without installation. This closes ticket #61