### PR TITLE
Fix for utf-8 URLs and for URLs with multiple instance of the same param

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -469,7 +469,7 @@ class Request(dict):
         # Include any query string parameters from the provided URL
         query = urlparse.urlparse(self.url)[4]
 
-        url_items = self._split_url_string(query).items()
+        url_items = self._split_url_string(query)
         url_items = [(to_utf8(k), to_utf8(v)) for k, v in url_items if k != 'oauth_signature' ]
         items.extend(url_items)
 
@@ -606,9 +606,11 @@ class Request(dict):
     @staticmethod
     def _split_url_string(param_str):
         """Turn URL string into parameters."""
-        parameters = parse_qs(param_str.encode('utf-8'), keep_blank_values=True)
-        for k, v in parameters.iteritems():
-            parameters[k] = urllib.unquote(v[0])
+        parsed = parse_qs(param_str.encode('utf-8'), keep_blank_values=True)
+        parameters = []
+        for k, v in parsed.iteritems():
+            for w in v:
+                parameters.append((k, urllib.unquote(w)))
         return parameters
 
 

--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -418,7 +418,7 @@ class Request(dict):
         except AttributeError:
             # must be python <2.5
             query = base_url[4]
-        query = parse_qs(query)
+        query = parse_qs(query.encode('utf-8'))
         for k, v in self.items():
             query.setdefault(k, []).append(v)
         

--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -610,7 +610,7 @@ class Request(dict):
         parameters = []
         for k, v in parsed.iteritems():
             for w in v:
-                parameters.append((k, urllib.unquote(w)))
+                parameters.append((k, w))
         return parameters
 
 

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -881,7 +881,7 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
 
         exp = parse_qs(qs, keep_blank_values=False)
         for k, v in exp.iteritems():
-            exp[k] = urllib.unquote(v[0])
+            exp[k] = v[0]
 
         self.assertEquals(exp, req.copy())
 
@@ -923,6 +923,14 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
         self.assertEquals(req['oauth_token'], tok.key)
         self.assertEquals(req['oauth_consumer_key'], con.key)
         self.assertEquals(tok.verifier, req['oauth_verifier'])
+
+    def test_split_url_string(self):
+        param_str = u"foo=bar&bar=édulcoré&baz=%25de"
+
+        params = oauth.Request._split_url_string(param_str)
+        params.sort()
+        self.assertEquals(params, [('bar', 'édulcoré'), ('baz', '%de'), ('foo', 'bar')])
+
 
 class SignatureMethod_Bad(oauth.SignatureMethod):
     name = "BAD"


### PR DESCRIPTION
Two fixes for two different problems (hope it's ok, otherwise I can create two forks for them...):
* Encode query before giving it to parse_qs to avoid problems when decoding %xx codes
* Rewrote _split_url_string to return a list of tuples instead of a dict to allow multiple instances of the same param in an url

This two changes were added so I can request the LinkedIn search API. For instance, to find "Développeur" in France working in the "Computer Software" industry:

http://api.linkedin.com/v1/people-search:(people)?title=D%C3%A9veloppeur&facets=location%2Cindustry&facet=location%2Cfr%3A0&facet=industry%2C4