### PR TITLE
to_header now escapes auth_header string.

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -393,7 +393,7 @@ class Request(dict):
         header_params = ('%s="%s"' % (k, v) for k, v in stringy_params)
         params_header = ', '.join(header_params)
  
-        auth_header = escape('OAuth realm="%s"' % realm)
+        auth_header = 'OAuth realm="%s"' % escape(realm)
         if params_header:
             auth_header = "%s, %s" % (auth_header, params_header)
  


### PR DESCRIPTION
oauth2.client automatically includes the URL as the realm. This is fine,
but per the OAuth spec (http://oauth.net/core/1.0/), special charaters in
the realm should be escaped. Escaping the auth_header string brings oauth2
in compliance with the spec, and fixes an issue we had validating against
an oauth server.
