### PR TITLE
Make "oauth_body_hash" a unicode string

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -491,6 +491,7 @@ class Request(dict):
             # oauth_body_hash parameter on requests with form-encoded
             # request bodies."
             self['oauth_body_hash'] = base64.b64encode(sha(self.body).digest())
+            self['oauth_body_hash'] = unicode(self['oauth_body_hash'])
 
         if 'oauth_consumer_key' not in self:
             self['oauth_consumer_key'] = consumer.key


### PR DESCRIPTION
Ensure "oauth_body_hash" is a unicode string, otherwise GET requests may fail to validate properly.

I created a request through Request.from_request() and noticed that if I print out the internal values, all of the attributes were unicode strings except for "oauth_body_hash".  My GET requests were also failing to validate.  After adding this line, that resolved the issue.
