### PR TITLE
Fixed request token parsing using cgi.parse_qs method

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -284,7 +284,7 @@ class Token(object):
         if not len(s):
             raise ValueError("Invalid parameter string.")
 
-        params = parse_qs(s, keep_blank_values=False)
+        params = parse_qs(s, keep_blank_values=True)
         if not len(params):
             raise ValueError("Invalid parameter string.")
 


### PR DESCRIPTION
keep_blank_values in OAuthToken.from_string method should be set True, otherwise you will get an unhandled exception trying fetch oauth_token_secret from response if OAuth server doesn't supply this parameter. For example Evernote's OAuth server doesn't provide oauth_token_secret parameter if signature method is PLAINTEXT.
