### PR TITLE
Avoid corruption of headers dict passed by client to Client.request

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -23,6 +23,7 @@ THE SOFTWARE.
 """
 
 import base64
+import copy
 import urllib
 import time
 import random
@@ -642,6 +643,8 @@ class Client(httplib2.Http):
 
         if not isinstance(headers, dict):
             headers = {}
+        else:
+            headers = copy.copy(headers)
 
         if method == "POST":
             headers['Content-Type'] = headers.get('Content-Type', 


### PR DESCRIPTION
Before this the Client.request method was able to corrupt the headers dict
passed by the user, since all complex objects are passed by reference.
