### PR TITLE
Fix UnicodeEncodeError in urllib if non-ascii characters are present in Request parameters

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -418,23 +418,23 @@ class Request(dict):
         except AttributeError:
             # must be python <2.5
             query = base_url[4]
-        query = parse_qs(query)
+        query = parse_qs(query.encode('utf-8'))
         for k, v in self.items():
-            query.setdefault(k, []).append(v)
+            query.setdefault(k.encode('utf-8'), []).append(to_utf8_optional_iterator(v))
         
         try:
-            scheme = base_url.scheme
-            netloc = base_url.netloc
-            path = base_url.path
-            params = base_url.params
-            fragment = base_url.fragment
+            scheme = base_url.scheme.encode('utf-8')
+            netloc = base_url.netloc.encode('utf-8')
+            path = base_url.path.encode('utf-8')
+            params = base_url.params.encode('utf-8')
+            fragment = base_url.fragment.encode('utf-8')
         except AttributeError:
             # must be python <2.5
-            scheme = base_url[0]
-            netloc = base_url[1]
-            path = base_url[2]
-            params = base_url[3]
-            fragment = base_url[5]
+            scheme = base_url[0].encode('utf-8')
+            netloc = base_url[1].encode('utf-8')
+            path = base_url[2].encode('utf-8')
+            params = base_url[3].encode('utf-8')
+            fragment = base_url[5].encode('utf-8')
         
         url = (scheme, netloc, path, params,
                urllib.urlencode(query, True), fragment)

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -448,6 +448,33 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
         kf = lambda x: x[0]
         self.assertEquals(sorted(flat, key=kf), sorted(parse_qsl(req.to_postdata()), key=kf))
 
+    def test_to_url_nonascii(self):
+        url = "http://sp.example.com/"
+
+        params = {
+            'nonasciithing': u'q\xbfu\xe9 ,aasp u?..a.s',
+            'oauth_version': "1.0",
+            'oauth_nonce': "4572616e48616d6d65724c61686176",
+            'oauth_timestamp': "137131200",
+            'oauth_consumer_key': "0685bd9184jfhq22",
+            'oauth_signature_method': "HMAC-SHA1",
+            'oauth_token': "ad180jjd733klru7",
+            'oauth_signature': "wOJIO9A2W5mFwDgiDvZbTSMK%2FPY%3D",
+        }
+
+        req = oauth.Request("GET", url, params)
+        res = urlparse.urlparse(req.to_url())
+
+        params['nonasciithing'] = params['nonasciithing'].encode('utf-8')
+        exp = urlparse.urlparse("%s?%s" % (url, urllib.urlencode(params)))
+
+        self.assertEquals(exp.netloc, res.netloc)
+        self.assertEquals(exp.path, res.path)
+
+        a = parse_qs(exp.query)
+        b = parse_qs(res.query)
+        self.assertEquals(a, b)
+
     def test_to_url(self):
         url = "http://sp.example.com/"
 


### PR DESCRIPTION
Request.to_postdata was fixed some time ago, but Request.to_url was still unable to create url when unicode characters were present in any of Request parameters (because of UnicodeEncodeError)

See included test.