### PR TITLE
fix multivalued param dict handling in to_url, fix oauth_body_hash sending for GET requests

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -421,7 +421,7 @@ class Request(dict):
         query = parse_qs(query)
         for k, v in self.items():
             # deal with multivalued parameters properly
-            if isinstance(v,list):
+            if hasattr(v, "__iter__"):
                 query.setdefault(k, []).extend(v)
             else:
                 query.setdefault(k, []).append(v)     


### PR DESCRIPTION
These patches fix multivalued param handling for the case when you pass a dictionary with iterable values into a request and then call to_url. Previously this would encode the iterable value as a single string instead of encoding each value separately. 

This also fixes the library to not send the "oauth_body_hash" parameter on GET or HEAD requests, as defined in the spec.
