### PR TITLE
Bug fix for python2.4

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -490,7 +490,11 @@ class Request(dict):
             # section 4.1.1 "OAuth Consumers MUST NOT include an
             # oauth_body_hash parameter on requests with form-encoded
             # request bodies."
-            self['oauth_body_hash'] = base64.b64encode(sha(self.body).digest())
+            try:
+                self['oauth_body_hash'] = base64.b64encode(sha(self.body).digest())
+            except TypeError:
+                # for Pythons 2.4 and lower
+                self['oauth_body_hash'] = base64.b64encode(sha.new(self.body).digest())
 
         if 'oauth_consumer_key' not in self:
             self['oauth_consumer_key'] = consumer.key


### PR DESCRIPTION
Using oauth2 with Python2.4, I get the following error:

    oauth_request.sign_request(oauth2.SignatureMethod_HMAC_SHA1(), consumer, None)
  File "/home/deploy/boss/oauth2/__init__.py", line 493, in sign_request
    self['oauth_body_hash'] = base64.b64encode(sha(self.body).digest())
TypeError: 'module' object is not callable


This is because you need to create a new sha object using sha.new and then call digest on that object.