### PR TITLE
Two patches to make the client work better with a picky resource

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -637,7 +637,7 @@ class Client(httplib2.Http):
         self.method = method
 
     def request(self, uri, method="GET", body='', headers=None, 
-        redirections=httplib2.DEFAULT_MAX_REDIRECTS, connection_type=None):
+        redirections=httplib2.DEFAULT_MAX_REDIRECTS, connection_type=None, realm=None):
         DEFAULT_POST_CONTENT_TYPE = 'application/x-www-form-urlencoded'
 
         if not isinstance(headers, dict):
@@ -661,14 +661,15 @@ class Client(httplib2.Http):
 
         req.sign_request(self.method, self.consumer, self.token)
 
-        schema, rest = urllib.splittype(uri)
-        if rest.startswith('//'):
-            hierpart = '//'
-        else:
-            hierpart = ''
-        host, rest = urllib.splithost(rest)
+        if not realm:
+            schema, rest = urllib.splittype(uri)
+            if rest.startswith('//'):
+                hierpart = '//'
+            else:
+                hierpart = ''
+            host, rest = urllib.splithost(rest)
 
-        realm = schema + ':' + hierpart + host
+            realm = schema + ':' + hierpart + host
 
         if is_form_encoded:
             body = req.to_postdata()


### PR DESCRIPTION
I have a picky backend that has two features not supported by the Client class.

a) It wants JSON in the POST body instead of x-www-form-encoded, so I peek into the headers and don't overwrite Content-Type if it is already set, default behavior remains
b) cares about the Authentication realm bit, I added a parameter that sets the realm in the request, default behavior remains.
