### PR TITLE
use the '__iter__' attribute to determine if something is iterable vs a volatile error message

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -40,9 +40,10 @@ except ImportError:
 
 try:
     from hashlib import sha1
-    sha = sha1
+    sha_new = sha = sha1
 except ImportError:
     # hashlib was added in Python 2.5
+    import sha as sha_new
     from sha import sha
 
 import _version
@@ -828,7 +829,7 @@ class SignatureMethod_HMAC_SHA1(SignatureMethod):
         """Builds the base signature string."""
         key, raw = self.signing_base(request, consumer, token)
 
-        hashed = hmac.new(key, raw, sha)
+        hashed = hmac.new(key, raw, sha_new)
 
         # Calculate the digest base 64.
         return binascii.b2a_base64(hashed.digest())[:-1]


### PR DESCRIPTION
oauth2 uses the error string 'is not iterable' after try to cast to a list:

https://github.com/simplegeo/python-oauth2/blob/master/oauth2/__init__.py#L135

This is a fragile way of determining if something is an iterable or not.  Instead, the '**iter**'  attribute can be checked for.

As a case in point, for python 2.4 the error message is:

> > > list(12345)
> > > Traceback (most recent call last):
> > >   File "<stdin>", line 1, in ?
> > > TypeError: iteration over non-sequence

See https://bugzilla.mozilla.org/show_bug.cgi?id=789972#c12 which is the motivation for this pull request
