### PR TITLE
Python 3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
-from setuptools import setup
-import os, re
+import os, re, sys
+
+from setuptools import setup, find_packages
 
 PKG='oauth2'
 VERSIONFILE = os.path.join('oauth2', '_version.py')
@@ -15,7 +16,7 @@ else:
     if mo:
         mverstr = mo.group(1)
     else:
-        print "unable to find version in %s" % (VERSIONFILE,)
+        sys.stdout.write("unable to find version in %s\n" % (VERSIONFILE,))
         raise RuntimeError("if %s.py exists, it must be well-formed" % (VERSIONFILE,))
     AVSRE = r"^auto_build_num *= *['\"]([^'\"]*)['\"]"
     mo = re.search(AVSRE, verstrline, re.M)

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -758,7 +758,6 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
         req = oauth.Request("GET", url, None)
         self.assertEquals(req.normalized_url, 'http://social.yahooapis.com/v1/user/6677/connections;start=0;count=20')
         self.assertEquals(req.url, 'http://social.yahooapis.com/v1/user/6677/connections;start=0;count=20')
-        self.assertEqual(urlencode(sorted(foo.items())), res)
 
     def test_set_signature_method(self):
         consumer = oauth.Consumer('key', 'secret')

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -92,7 +92,7 @@ class TestError(unittest.TestCase):
             raise oauth.Error
         except oauth.Error:
             e = sys.exc_info()[1]
-            self.assertEquals(str(e), 'OAuth error occurred.')
+            self.assertEqual(str(e), 'OAuth error occurred.')
 
 class TestGenerateFunctions(unittest.TestCase):
     def test_build_auth_header(self):
@@ -122,16 +122,16 @@ class TestGenerateFunctions(unittest.TestCase):
             var, val = part.split('=')
             returned[var] = val.strip('"') 
 
-        self.assertEquals('HMAC-SHA1', returned['oauth_signature_method'])
-        self.assertEquals('user_token', returned['oauth_token'])
-        self.assertEquals('consumer_token', returned['oauth_consumer_key'])
+        self.assertEqual('HMAC-SHA1', returned['oauth_signature_method'])
+        self.assertEqual('user_token', returned['oauth_token'])
+        self.assertEqual('consumer_token', returned['oauth_consumer_key'])
         self.assertTrue('oauth_signature' in returned, 'oauth_signature')
 
     def test_escape(self):
         string = 'http://whatever.com/~someuser/?test=test&other=other'
-        self.assert_('~' in oauth.escape(string))
+        self.assertTrue('~' in oauth.escape(string))
         string = '../../../../../../../etc/passwd'
-        self.assert_('../' not in oauth.escape(string))
+        self.assertTrue('../' not in oauth.escape(string))
 
     def test_gen_nonce(self):
         nonce = oauth.generate_nonce()
@@ -169,8 +169,8 @@ class TestConsumer(unittest.TestCase):
         res = dict(parse_qsl(str(self.consumer)))
         self.assertTrue('oauth_consumer_key' in res)
         self.assertTrue('oauth_consumer_secret' in res)
-        self.assertEquals(res['oauth_consumer_key'], self.consumer.key)
-        self.assertEquals(res['oauth_consumer_secret'], self.consumer.secret)
+        self.assertEqual(res['oauth_consumer_key'], self.consumer.key)
+        self.assertEqual(res['oauth_consumer_secret'], self.consumer.secret)
 
 class TestToken(unittest.TestCase):
     def setUp(self):
@@ -282,20 +282,21 @@ class TestToken(unittest.TestCase):
 
 class ReallyEqualMixin:
     def failUnlessReallyEqual(self, a, b, msg=None):
-        self.failUnlessEqual(a, b, msg=msg)
-        self.failUnlessEqual(type(a), type(b), msg="a :: %r, b :: %r, %r" % (a, b, msg))
+        self.assertEqual(a, b, msg=msg)
+        self.assertEqual(type(a), type(b), msg="a :: %r, b :: %r, %r" % (a, b, msg))
 
 class TestFuncs(unittest.TestCase):
     def test_to_unicode(self):
-        self.failUnlessRaises(TypeError, oauth.to_unicode, '\xae')
-        self.failUnlessRaises(TypeError, oauth.to_unicode_optional_iterator, '\xae')
-        self.failUnlessRaises(TypeError, oauth.to_unicode_optional_iterator, ['\xae'])
+        if not PY3:
+            self.assertRaises(TypeError, oauth.to_unicode, '\xae')
+            self.assertRaises(TypeError, oauth.to_unicode_optional_iterator, '\xae')
+            self.assertRaises(TypeError, oauth.to_unicode_optional_iterator, ['\xae'])
+            self.assertEqual(oauth.to_unicode('\xc2\xae'), _u('\u00ae'))
 
-        self.failUnlessEqual(oauth.to_unicode(':-)'), _u(':-)'))
-        self.failUnlessEqual(oauth.to_unicode(_u('\u00ae'), _u('\u00ae')))
-        self.failUnlessEqual(oauth.to_unicode('\xc2\xae'), _u('\u00ae'))
-        self.failUnlessEqual(oauth.to_unicode_optional_iterator([':-)']), [_u(':-)')])
-        self.failUnlessEqual(oauth.to_unicode_optional_iterator([_u('\u00ae')]), [_u('\u00ae')])
+        self.assertEqual(oauth.to_unicode(':-)'), _u(':-)'))
+        self.assertEqual(oauth.to_unicode(_u('\u00ae')), _u('\u00ae'))
+        self.assertEqual(oauth.to_unicode_optional_iterator([':-)']), [_u(':-)')])
+        self.assertEqual(oauth.to_unicode_optional_iterator([_u('\u00ae')]), [_u('\u00ae')])
 
 class TestRequest(unittest.TestCase, ReallyEqualMixin):
     def test_setter(self):
@@ -328,12 +329,12 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
         method = "GET"
 
         req = oauth.Request(method, url1)
-        self.assertEquals(req.normalized_url, exp1)
-        self.assertEquals(req.url, url1)
+        self.assertEqual(req.normalized_url, exp1)
+        self.assertEqual(req.url, url1)
 
         req = oauth.Request(method, url2)
-        self.assertEquals(req.normalized_url, exp2)
-        self.assertEquals(req.url, url2)
+        self.assertEqual(req.normalized_url, exp2)
+        self.assertEqual(req.url, url2)
 
     def test_bad_url(self):
         request = oauth.Request()
@@ -350,8 +351,8 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
         request.sign_request(oauth.SignatureMethod_HMAC_SHA1(), consumer,
             token)
 
-        self.assertEquals(consumer.key, request['oauth_consumer_key'])
-        self.assertEquals(token.key, request['oauth_token'])
+        self.assertEqual(consumer.key, request['oauth_consumer_key'])
+        self.assertEqual(token.key, request['oauth_token'])
 
     def test_no_url_set(self):
         consumer = oauth.Consumer('my_consumer_key', 'my_consumer_secret')
@@ -373,8 +374,8 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
         method = "GET"
         
         req = oauth.Request(method, url)
-        self.assertEquals(req.url, url)
-        self.assertEquals(req.normalized_url, normalized_url)
+        self.assertEqual(req.url, url)
+        self.assertEqual(req.normalized_url, normalized_url)
 
     def test_get_parameter(self):
         url = "http://example.com"
@@ -382,7 +383,7 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
         params = {'oauth_consumer' : 'asdf'}
         req = oauth.Request(method, url, parameters=params)
 
-        self.assertEquals(req.get_parameter('oauth_consumer'), 'asdf')
+        self.assertEqual(req.get_parameter('oauth_consumer'), 'asdf')
         self.assertRaises(oauth.Error, req.get_parameter, 'blah')
 
     def test_get_nonoauth_parameters(self):
@@ -404,7 +405,7 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
         params.update(other_params)
 
         req = oauth.Request("GET", "http://example.com", params)
-        self.assertEquals(other_params, req.get_nonoauth_parameters())
+        self.assertEqual(other_params, req.get_nonoauth_parameters())
 
     def test_to_url_nonascii(self):
         url = "http://sp.example.com/"
@@ -484,13 +485,13 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
             var, val = v.split('=')
             res[var] = unquote(val.strip('"'))
 
-        self.assertEquals(realm, res['realm'])
+        self.assertEqual(realm, res['realm'])
         del res['realm']
 
         self.assertTrue(len(res), len(params))
 
         for key, val in res.items():
-            self.assertEquals(val, params.get(key))
+            self.assertEqual(val, params.get(key))
 
     def test_to_postdata_nonascii(self):
         realm = "http://sp.example.com/"
@@ -530,7 +531,7 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
         del params['multi']
         flat.extend(params.items())
         kf = lambda x: x[0]
-        self.assertEquals(sorted(flat, key=kf), sorted(parse_qsl(req.to_postdata()), key=kf))
+        self.assertEqual(sorted(flat, key=kf), sorted(parse_qsl(req.to_postdata()), key=kf))
 
     def test_to_url(self):
         url = "http://sp.example.com/"
@@ -548,13 +549,13 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
         req = oauth.Request("GET", url, params)
         exp = urlparse.urlparse("%s?%s" % (url, urlencode(params)))
         res = urlparse.urlparse(req.to_url())
-        self.assertEquals(exp.scheme, res.scheme)
-        self.assertEquals(exp.netloc, res.netloc)
-        self.assertEquals(exp.path, res.path)
+        self.assertEqual(exp.scheme, res.scheme)
+        self.assertEqual(exp.netloc, res.netloc)
+        self.assertEqual(exp.path, res.path)
 
         a = parse_qs(exp.query)
         b = parse_qs(res.query)
-        self.assertEquals(a, b)
+        self.assertEqual(a, b)
     
     def test_to_url_with_query(self):
         url = "https://www.google.com/m8/feeds/contacts/default/full/?alt=json&max-contacts=10"
@@ -573,17 +574,17 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
         # Note: the url above already has query parameters, so append new ones with &
         exp = urlparse.urlparse("%s&%s" % (url, urlencode(params)))
         res = urlparse.urlparse(req.to_url())
-        self.assertEquals(exp.scheme, res.scheme)
-        self.assertEquals(exp.netloc, res.netloc)
-        self.assertEquals(exp.path, res.path)
+        self.assertEqual(exp.scheme, res.scheme)
+        self.assertEqual(exp.netloc, res.netloc)
+        self.assertEqual(exp.path, res.path)
 
         a = parse_qs(exp.query)
         b = parse_qs(res.query)
         self.assertTrue('alt' in b)
         self.assertTrue('max-contacts' in b)
-        self.assertEquals(b['alt'], ['json'])
-        self.assertEquals(b['max-contacts'], ['10'])
-        self.assertEquals(a, b)
+        self.assertEqual(b['alt'], ['json'])
+        self.assertEqual(b['max-contacts'], ['10'])
+        self.assertEqual(a, b)
 
     def test_signature_base_string_nonascii_nonutf8(self):
         consumer = oauth.Consumer('consumer_token', 'consumer_secret')
@@ -594,11 +595,12 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
         req.sign_request(oauth.SignatureMethod_HMAC_SHA1(), consumer, None)
         self.failUnlessReallyEqual(req['oauth_signature'], 'WhufgeZKyYpKsI70GZaiDaYwl6g=')
 
-        url = 'http://api.simplegeo.com:80/1.0/places/address.json?q=monkeys&category=animal&address=41+Decatur+St,+San+Francisc\xe2\x9d\xa6,+CA'
-        req = oauth.Request("GET", url)
-        self.failUnlessReallyEqual(req.normalized_url, _u('http://api.simplegeo.com/1.0/places/address.json'))
-        req.sign_request(oauth.SignatureMethod_HMAC_SHA1(), consumer, None)
-        self.failUnlessReallyEqual(req['oauth_signature'], 'WhufgeZKyYpKsI70GZaiDaYwl6g=')
+        if not PY3:
+            url = 'http://api.simplegeo.com:80/1.0/places/address.json?q=monkeys&category=animal&address=41+Decatur+St,+San+Francisc\xe2\x9d\xa6,+CA'
+            req = oauth.Request("GET", url)
+            self.failUnlessReallyEqual(req.normalized_url, _u('http://api.simplegeo.com/1.0/places/address.json'))
+            req.sign_request(oauth.SignatureMethod_HMAC_SHA1(), consumer, None)
+            self.failUnlessReallyEqual(req['oauth_signature'], 'WhufgeZKyYpKsI70GZaiDaYwl6g=')
 
         url = 'http://api.simplegeo.com:80/1.0/places/address.json?q=monkeys&category=animal&address=41+Decatur+St,+San+Francisc%E2%9D%A6,+CA'
         req = oauth.Request("GET", url)
@@ -624,17 +626,17 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
             'oauth_signature': "wOJIO9A2W5mFwDgiDvZbTSMK%2FPY%3D",
         }
         req = oauth.Request("GET", url, params)
-        self.assertEquals(req.normalized_url, 'https://www.google.com/m8/feeds/contacts/default/full/')
-        self.assertEquals(req.url, 'https://www.google.com/m8/feeds/contacts/default/full/?alt=json&max-contacts=10')
+        self.assertEqual(req.normalized_url, 'https://www.google.com/m8/feeds/contacts/default/full/')
+        self.assertEqual(req.url, 'https://www.google.com/m8/feeds/contacts/default/full/?alt=json&max-contacts=10')
         normalized_params = parse_qsl(req.get_normalized_parameters())
         self.assertTrue(len(normalized_params), len(params) + 2)
         normalized_params = dict(normalized_params)
         for key, value in iteritems(params):
             if key == 'oauth_signature':
                 continue
-            self.assertEquals(value, normalized_params[key])
-        self.assertEquals(normalized_params['alt'], 'json')
-        self.assertEquals(normalized_params['max-contacts'], '10')
+            self.assertEqual(value, normalized_params[key])
+        self.assertEqual(normalized_params['alt'], 'json')
+        self.assertEqual(normalized_params['max-contacts'], '10')
 
     def test_get_normalized_parameters_empty(self):
         url = "http://sp.example.com/?empty="
@@ -645,7 +647,7 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
 
         expected='empty='
 
-        self.assertEquals(expected, res)
+        self.assertEqual(expected, res)
 
     def test_get_normalized_parameters_duplicate(self):
         url = "http://example.com/v2/search/videos?oauth_nonce=79815175&oauth_timestamp=1295397962&oauth_consumer_key=mykey&oauth_signature_method=HMAC-SHA1&q=car&oauth_version=1.0&offset=10&oauth_signature=spWLI%2FGQjid7sQVd5%2FarahRxzJg%3D"
@@ -656,7 +658,7 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
 
         expected='oauth_consumer_key=mykey&oauth_nonce=79815175&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1295397962&oauth_version=1.0&offset=10&q=car'
 
-        self.assertEquals(expected, res)
+        self.assertEqual(expected, res)
 
     def test_get_normalized_parameters_multiple(self):
         url = "http://example.com/v2/search/videos?oauth_nonce=79815175&oauth_timestamp=1295397962&oauth_consumer_key=mykey&oauth_signature_method=HMAC-SHA1&oauth_version=1.0&offset=10&oauth_signature=spWLI%2FGQjid7sQVd5%2FarahRxzJg%3D&tag=one&tag=two"
@@ -683,7 +685,7 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
 
         expected = 'file=vacation.jpg&oauth_consumer_key=dpf43f3p2l4k3l03&oauth_nonce=kllo9940pd9333jh&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1191242096&oauth_token=nnch734d00sl2jdk&oauth_version=1.0&size=original'
 
-        self.assertEquals(expected, res)
+        self.assertEqual(expected, res)
 
     def test_signing_base(self):
         # example copied from
@@ -700,7 +702,7 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
         key, raw = sm.signing_base(req, consumer, None)
 
         expected = 'GET&http%3A%2F%2Fphotos.example.net%2Fphotos&file%3Dvacation.jpg%26oauth_consumer_key%3Ddpf43f3p2l4k3l03%26oauth_nonce%3Dkllo9940pd9333jh%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1191242096%26oauth_token%3Dnnch734d00sl2jdk%26oauth_version%3D1.0%26size%3Doriginal'
-        self.assertEquals(expected, raw)
+        self.assertEqual(expected, raw)
 
     def test_get_normalized_parameters(self):
         url = "http://sp.example.com/"
@@ -722,9 +724,11 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
 
         res = req.get_normalized_parameters()
 
-        expected='multi=BAR&multi=FOO&multi=%C2%AE&multi=%C2%AE&multi_same=FOO&multi_same=FOO&oauth_consumer_key=0685bd9184jfhq22&oauth_nonce=4572616e48616d6d65724c61686176&oauth_signature_method=HMAC-SHA1&oauth_timestamp=137131200&oauth_token=ad180jjd733klru7&oauth_version=1.0&uni_unicode_object=%C2%AE&uni_utf8_bytes=%C2%AE'
+        expected = 'multi=BAR&multi=FOO&multi=%C2%AE&multi=%C2%AE&multi_same=FOO&multi_same=FOO&oauth_consumer_key=0685bd9184jfhq22&oauth_nonce=4572616e48616d6d65724c61686176&oauth_signature_method=HMAC-SHA1&oauth_timestamp=137131200&oauth_token=ad180jjd733klru7&oauth_version=1.0&uni_unicode_object=%C2%AE&uni_utf8_bytes=%C2%AE'
+        if PY3:
+            expected = 'multi=BAR&multi=FOO&multi=%C2%AE&multi=%C3%82%C2%AE&multi_same=FOO&multi_same=FOO&oauth_consumer_key=0685bd9184jfhq22&oauth_nonce=4572616e48616d6d65724c61686176&oauth_signature_method=HMAC-SHA1&oauth_timestamp=137131200&oauth_token=ad180jjd733klru7&oauth_version=1.0&uni_unicode_object=%C2%AE&uni_utf8_bytes=%C3%82%C2%AE'
 
-        self.assertEquals(expected, res)
+        self.assertEqual(expected, res)
 
     def test_get_normalized_parameters_ignores_auth_signature(self):
         url = "http://sp.example.com/"
@@ -743,7 +747,7 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
 
         res = req.get_normalized_parameters()
 
-        self.assertNotEquals(urlencode(sorted(params.items())), res)
+        self.assertNotEqual(urlencode(sorted(params.items())), res)
 
         foo = params.copy()
         del foo["oauth_signature"]
@@ -771,7 +775,7 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
 
         m = oauth.SignatureMethod_HMAC_SHA1()
         client.set_signature_method(m)
-        self.assertEquals(m, client.method)
+        self.assertEqual(m, client.method)
 
     def test_get_normalized_string_escapes_spaces_properly(self):
         url = "http://sp.example.com/"
@@ -801,10 +805,11 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
             'oauth_consumer_key': con.key
         }
 
-        # If someone passes a sequence of bytes which is not ascii for
-        # url, we'll raise an exception as early as possible.
-        url = "http://sp.example.com/\x92" # It's actually cp1252-encoding...
-        self.assertRaises(TypeError, oauth.Request, method="GET", url=url, parameters=params)
+        if not PY3:
+            # If someone passes a sequence of bytes which is not ascii for
+            # url, we'll raise an exception as early as possible.
+            url = "http://sp.example.com/\x92" # It's actually cp1252-encoding...
+            self.assertRaises(TypeError, oauth.Request, method="GET", url=url, parameters=params)
 
         # And if they pass an unicode, then we'll use it.
         url = _u('http://sp.example.com/\u2019')
@@ -822,10 +827,11 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
         # Same thing with the params.
         url = "http://sp.example.com/"
 
-        # If someone passes a sequence of bytes which is not ascii in
-        # params, we'll raise an exception as early as possible.
-        params['non_oauth_thing'] = '\xae', # It's actually cp1252-encoding...
-        self.assertRaises(TypeError, oauth.Request, method="GET", url=url, parameters=params)
+        if not PY3:
+            # If someone passes a sequence of bytes which is not ascii in
+            # params, we'll raise an exception as early as possible.
+            params['non_oauth_thing'] = '\xae', # It's actually cp1252-encoding...
+            self.assertRaises(TypeError, oauth.Request, method="GET", url=url, parameters=params)
 
         # And if they pass a unicode, then we'll use it.
         params['non_oauth_thing'] = _u('\u2019')
@@ -838,12 +844,16 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
         params['non_oauth_thing'] = '\xc2\xae'
         req = oauth.Request(method="GET", url=url, parameters=params)
         req.sign_request(oauth.SignatureMethod_HMAC_SHA1(), con, None)
-        self.failUnlessReallyEqual(req['oauth_signature'], 'pqOCu4qvRTiGiXB8Z61Jsey0pMM=')
+        expected = 'pqOCu4qvRTiGiXB8Z61Jsey0pMM='
+        if PY3:
+            expected = 'zHfzdfpczALRdfMO2u6x+2M4ibk='
+        self.failUnlessReallyEqual(req['oauth_signature'], expected)
 
 
-        # Also if there are non-utf8 bytes in the query args.
-        url = "http://sp.example.com/?q=\x92" # cp1252
-        self.assertRaises(TypeError, oauth.Request, method="GET", url=url, parameters=params)
+        if not PY3:
+            # Also if there are non-utf8 bytes in the query args.
+            url = "http://sp.example.com/?q=\x92" # cp1252
+            self.assertRaises(TypeError, oauth.Request, method="GET", url=url, parameters=params)
 
     def test_request_hash_of_body(self):
         tok = oauth.Token(key="token", secret="tok-test-secret")
@@ -922,30 +932,32 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
 
         for exp, method in methods.items():
             req.sign_request(method, con, tok)
-            self.assertEquals(req['oauth_signature_method'], method.name)
-            self.assertEquals(req['oauth_signature'], exp)
+            self.assertEqual(req['oauth_signature_method'], method.name)
+            self.assertEqual(req['oauth_signature'], exp)
 
-        # Also if there are non-ascii chars in the URL.
-        url = "http://sp.example.com/\xe2\x80\x99" # utf-8 bytes
-        req = oauth.Request(method="GET", url=url, parameters=params)
-        req.sign_request(oauth.SignatureMethod_HMAC_SHA1(), con, tok)
-        self.assertEquals(req['oauth_signature'], 'loFvp5xC7YbOgd9exIO6TxB7H4s=')
+        if not PY3:
+            # Also if there are non-ascii chars in the URL.
+            url = "http://sp.example.com/\xe2\x80\x99" # utf-8 bytes
+            req = oauth.Request(method="GET", url=url, parameters=params)
+            req.sign_request(oauth.SignatureMethod_HMAC_SHA1(), con, tok)
+            self.assertEqual(req['oauth_signature'], 'loFvp5xC7YbOgd9exIO6TxB7H4s=')
 
         url = _u('http://sp.example.com/\u2019') # Python unicode object
         req = oauth.Request(method="GET", url=url, parameters=params)
         req.sign_request(oauth.SignatureMethod_HMAC_SHA1(), con, tok)
-        self.assertEquals(req['oauth_signature'], 'loFvp5xC7YbOgd9exIO6TxB7H4s=')
+        self.assertEqual(req['oauth_signature'], 'loFvp5xC7YbOgd9exIO6TxB7H4s=')
 
-        # Also if there are non-ascii chars in the query args.
-        url = "http://sp.example.com/?q=\xe2\x80\x99" # utf-8 bytes
-        req = oauth.Request(method="GET", url=url, parameters=params)
-        req.sign_request(oauth.SignatureMethod_HMAC_SHA1(), con, tok)
-        self.assertEquals(req['oauth_signature'], 'IBw5mfvoCsDjgpcsVKbyvsDqQaU=')
+        if not PY3:
+            # Also if there are non-ascii chars in the query args.
+            url = "http://sp.example.com/?q=\xe2\x80\x99" # utf-8 bytes
+            req = oauth.Request(method="GET", url=url, parameters=params)
+            req.sign_request(oauth.SignatureMethod_HMAC_SHA1(), con, tok)
+            self.assertEqual(req['oauth_signature'], 'IBw5mfvoCsDjgpcsVKbyvsDqQaU=')
 
         url = _u('http://sp.example.com/?q=\u2019') # Python unicode object
         req = oauth.Request(method="GET", url=url, parameters=params)
         req.sign_request(oauth.SignatureMethod_HMAC_SHA1(), con, tok)
-        self.assertEquals(req['oauth_signature'], 'IBw5mfvoCsDjgpcsVKbyvsDqQaU=')
+        self.assertEqual(req['oauth_signature'], 'IBw5mfvoCsDjgpcsVKbyvsDqQaU=')
 
 
     def test_from_request_works_with_wsgi(self):
@@ -1022,10 +1034,10 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
 
         # Test from the headers
         req = oauth.Request.from_request("GET", url, headers)
-        self.assertEquals(req.method, "GET")
-        self.assertEquals(req.url, url)
+        self.assertEqual(req.method, "GET")
+        self.assertEqual(req.url, url)
 
-        self.assertEquals(params, req.copy())
+        self.assertEqual(params, req.copy())
 
         # Test with bad OAuth headers
         bad_headers = {
@@ -1043,11 +1055,11 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
         for k, v in iteritems(exp):
             exp[k] = unquote(v[0])
 
-        self.assertEquals(exp, req.copy())
+        self.assertEqual(exp, req.copy())
 
         # Test that a boned from_request() call returns None
         req = oauth.Request.from_request("GET", url)
-        self.assertEquals(None, req)
+        self.assertEqual(None, req)
 
     def test_from_token_and_callback(self):
         url = "http://sp.example.com/"
@@ -1065,11 +1077,11 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
         tok = oauth.Token(key="tok-test-key", secret="tok-test-secret")
         req = oauth.Request.from_token_and_callback(tok)
         self.assertFalse('oauth_callback' in req)
-        self.assertEquals(req['oauth_token'], tok.key)
+        self.assertEqual(req['oauth_token'], tok.key)
 
         req = oauth.Request.from_token_and_callback(tok, callback=url)
         self.assertTrue('oauth_callback' in req)
-        self.assertEquals(req['oauth_callback'], url)
+        self.assertEqual(req['oauth_callback'], url)
 
     def test_from_consumer_and_token(self):
         url = "http://sp.example.com/"
@@ -1080,9 +1092,9 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
         req = oauth.Request.from_consumer_and_token(con, token=tok,
             http_method="GET", http_url=url)
 
-        self.assertEquals(req['oauth_token'], tok.key)
-        self.assertEquals(req['oauth_consumer_key'], con.key)
-        self.assertEquals(tok.verifier, req['oauth_verifier'])
+        self.assertEqual(req['oauth_token'], tok.key)
+        self.assertEqual(req['oauth_consumer_key'], con.key)
+        self.assertEqual(tok.verifier, req['oauth_verifier'])
 
 class SignatureMethod_Bad(oauth.SignatureMethod):
     name = "BAD"
@@ -1125,7 +1137,7 @@ class TestServer(unittest.TestCase):
             oauth.SignatureMethod_HMAC_SHA1))
 
         server = oauth.Server()
-        self.assertEquals(server.signature_methods, {})
+        self.assertEqual(server.signature_methods, {})
 
     def test_add_signature_method(self):
         server = oauth.Server()
@@ -1151,15 +1163,15 @@ class TestServer(unittest.TestCase):
         self.assertTrue('bar' in parameters)
         self.assertTrue('foo' in parameters)
         self.assertTrue('multi' in parameters)
-        self.assertEquals(parameters['bar'], 'blerg')
-        self.assertEquals(parameters['foo'], 59)
-        self.assertEquals(parameters['multi'], ['FOO','BAR'])
+        self.assertEqual(parameters['bar'], 'blerg')
+        self.assertEqual(parameters['foo'], 59)
+        self.assertEqual(parameters['multi'], ['FOO','BAR'])
 
     def test_build_authenticate_header(self):
         server = oauth.Server()
         headers = server.build_authenticate_header('example.com')
         self.assertTrue('WWW-Authenticate' in headers)
-        self.assertEquals('OAuth realm="example.com"', 
+        self.assertEqual('OAuth realm="example.com"', 
             headers['WWW-Authenticate'])
 
     def test_no_version(self):
@@ -1370,15 +1382,17 @@ class TestClient(unittest.TestCase):
         client = oauth.Client(self.consumer, None)
         resp, content = client.request(self._uri('request_token'), "GET")
 
-        self.assertEquals(int(resp['status']), 200)
+        self.assertEqual(int(resp['status']), 200)
 
     def test_access_token_post(self):
         """Test getting an access token via POST."""
         client = oauth.Client(self.consumer, None)
         resp, content = client.request(self._uri('request_token'), "POST")
 
-        self.assertEquals(int(resp['status']), 200)
+        self.assertEqual(int(resp['status']), 200)
 
+        if PY3:
+            content = content.decode('utf8')
         res = dict(parse_qsl(content))
         self.assertTrue('oauth_token' in res)
         self.assertTrue('oauth_token_secret' in res)
@@ -1393,12 +1407,12 @@ class TestClient(unittest.TestCase):
         """A test of a two-legged OAuth POST request."""
         resp, content = self._two_legged("POST")
 
-        self.assertEquals(int(resp['status']), 200)
+        self.assertEqual(int(resp['status']), 200)
 
     def test_two_legged_get(self):
         """A test of a two-legged OAuth GET request."""
         resp, content = self._two_legged("GET")
-        self.assertEquals(int(resp['status']), 200)
+        self.assertEqual(int(resp['status']), 200)
 
     @mock.patch('httplib2.Http.request')
     def test_multipart_post_does_not_alter_body(self, mockHttpRequest):
@@ -1413,14 +1427,14 @@ class TestClient(unittest.TestCase):
         uri = self._uri('two_legged')
 
         def mockrequest(cl, ur, **kw):
-            self.failUnless(cl is client)
-            self.failUnless(ur is uri)
-            self.failUnlessEqual(frozenset(kw.keys()), frozenset(['method', 'body', 'redirections', 'connection_type', 'headers']))
-            self.failUnlessEqual(kw['body'], body)
-            self.failUnlessEqual(kw['connection_type'], None)
-            self.failUnlessEqual(kw['method'], 'POST')
-            self.failUnlessEqual(kw['redirections'], httplib2.DEFAULT_MAX_REDIRECTS)
-            self.failUnless(isinstance(kw['headers'], dict))
+            self.assertTrue(cl is client)
+            self.assertTrue(ur is uri)
+            self.assertEqual(frozenset(kw.keys()), frozenset(['method', 'body', 'redirections', 'connection_type', 'headers']))
+            self.assertEqual(kw['body'], body)
+            self.assertEqual(kw['connection_type'], None)
+            self.assertEqual(kw['method'], 'POST')
+            self.assertEqual(kw['redirections'], httplib2.DEFAULT_MAX_REDIRECTS)
+            self.assertTrue(isinstance(kw['headers'], dict))
 
             return random_result
 
@@ -1436,24 +1450,24 @@ class TestClient(unittest.TestCase):
         random_result = random.randint(1,100)
 
         def mockrequest(cl, ur, **kw):
-            self.failUnless(cl is client)
-            self.failUnlessEqual(frozenset(kw.keys()), frozenset(['method', 'body', 'redirections', 'connection_type', 'headers']))
-            self.failUnlessEqual(kw['body'], '')
-            self.failUnlessEqual(kw['connection_type'], None)
-            self.failUnlessEqual(kw['method'], 'GET')
-            self.failUnlessEqual(kw['redirections'], httplib2.DEFAULT_MAX_REDIRECTS)
-            self.failUnless(isinstance(kw['headers'], dict))
+            self.assertTrue(cl is client)
+            self.assertEqual(frozenset(kw.keys()), frozenset(['method', 'body', 'redirections', 'connection_type', 'headers']))
+            self.assertEqual(kw['body'], '')
+            self.assertEqual(kw['connection_type'], None)
+            self.assertEqual(kw['method'], 'GET')
+            self.assertEqual(kw['redirections'], httplib2.DEFAULT_MAX_REDIRECTS)
+            self.assertTrue(isinstance(kw['headers'], dict))
 
             req = oauth.Request.from_consumer_and_token(self.consumer, None,
                     http_method='GET', http_url=uri, parameters={})
             req.sign_request(oauth.SignatureMethod_HMAC_SHA1(), self.consumer, None)
             expected = parse_qsl(urlparse.urlparse(req.to_url()).query)
             actual = parse_qsl(urlparse.urlparse(ur).query)
-            self.failUnlessEqual(len(expected), len(actual))
+            self.assertEqual(len(expected), len(actual))
             actual = dict(actual)
             for key, value in expected:
                 if key not in ('oauth_signature', 'oauth_nonce', 'oauth_timestamp'):
-                    self.failUnlessEqual(actual[key], value)
+                    self.assertEqual(actual[key], value)
 
             return random_result
 
@@ -1471,11 +1485,11 @@ class TestClient(unittest.TestCase):
 
         client.request('http://whatever', 'POST', body='multi=1&multi=2')
 
-        self.failUnlessEqual(mockReqConstructor.call_count, 1)
-        self.failUnlessEqual(mockReqConstructor.call_args[1]['parameters'], {'multi': ['1', '2']})
+        self.assertEqual(mockReqConstructor.call_count, 1)
+        self.assertEqual(mockReqConstructor.call_args[1]['parameters'], {'multi': ['1', '2']})
 
-        self.failUnless('multi=1' in mockHttpRequest.call_args[1]['body'])
-        self.failUnless('multi=2' in mockHttpRequest.call_args[1]['body'])
+        self.assertTrue('multi=1' in mockHttpRequest.call_args[1]['body'])
+        self.assertTrue('multi=2' in mockHttpRequest.call_args[1]['body'])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
All tests passing on latest versions of Python 2.5, 2.6, 2.7 & 3.2.

Python 2.4 tests fail, but were failing anyway. I'd advise the README is updated to reflect this.

Alternate expectations in tests are purely due to Python 3's handling of unicode strings.