### PR TITLE
Adds a keyword argument for explicitly setting the realm parameter for an OAuth Authorization header

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -637,7 +637,8 @@ class Client(httplib2.Http):
         self.method = method
 
     def request(self, uri, method="GET", body='', headers=None, 
-        redirections=httplib2.DEFAULT_MAX_REDIRECTS, connection_type=None):
+        redirections=httplib2.DEFAULT_MAX_REDIRECTS, connection_type=None,
+        realm=None):
         DEFAULT_POST_CONTENT_TYPE = 'application/x-www-form-urlencoded'
 
         if not isinstance(headers, dict):
@@ -668,7 +669,7 @@ class Client(httplib2.Http):
             hierpart = ''
         host, rest = urllib.splithost(rest)
 
-        realm = schema + ':' + hierpart + host
+        realm = realm if realm != None else schema + ':' + hierpart + host
 
         if is_form_encoded:
             body = req.to_postdata()


### PR DESCRIPTION
My need for this specifically came up because the OAuth implementation for the QuickBooks Online API rejects a realm of "https://qbo.sbfinance.intuit.com" ('WWW-Authenticate: OAuth oauth_problem="parameter_rejected", oauth_parameters_rejected="realm"') as auto-constructed from a request to "https://qbo.sbfinance.intuit.com/resource/customer..." but accepts a realm of "qbo.sbfinance.intuit.com".

As this override option is implemented as a keyword argument with a default, the revised version of the library should be wholly backward-compatible.

Best,
Jon
