### PR TITLE
Add missing comma to the README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This code was originally forked from [Leah Culver and Andy Smith's oauth.py code
     params = {
         'oauth_version': "1.0",
         'oauth_nonce': oauth.generate_nonce(),
-        'oauth_timestamp': int(time.time())
+        'oauth_timestamp': int(time.time()),
         'user': 'joestump',
         'photoid': 555555555555
     }


### PR DESCRIPTION
There was a missing comma in the README example.