### PR TITLE
Readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The <code>oauth2.Client</code> is based on <code>httplib2</code> and works just 
         secret="your-twitter-consumer-secret")
     
     # Request token URL for Twitter.
-    request_token_url = "http://twitter.com/oauth/request_token"
+    request_token_url = "https://api.twitter.com/oauth/request_token"
     
     # Create our client.
     client = oauth.Client(consumer)
@@ -77,9 +77,9 @@ can be easily translated to a web application.
     consumer_key = 'my_key_from_twitter'
     consumer_secret = 'my_secret_from_twitter'
     
-    request_token_url = 'http://twitter.com/oauth/request_token'
-    access_token_url = 'http://twitter.com/oauth/access_token'
-    authorize_url = 'http://twitter.com/oauth/authorize'
+    request_token_url = 'https://api.twitter.com/oauth/request_token'
+    access_token_url = 'https://api.twitter.com/oauth/access_token'
+    authorize_url = 'https://api.twitter.com/oauth/authorize'
     
     consumer = oauth.Consumer(consumer_key, consumer_secret)
     client = oauth.Client(consumer)
@@ -209,11 +209,11 @@ and code here might need to be updated if you are using Python 2.6+.
     consumer = oauth.Consumer(settings.TWITTER_TOKEN, settings.TWITTER_SECRET)
     client = oauth.Client(consumer)
 
-    request_token_url = 'http://twitter.com/oauth/request_token'
-    access_token_url = 'http://twitter.com/oauth/access_token'
+    request_token_url = 'https://api.twitter.com/oauth/request_token'
+    access_token_url = 'https://api.twitter.com/oauth/access_token'
 
     # This is the slightly different URL used to authenticate/authorize.
-    authenticate_url = 'http://twitter.com/oauth/authenticate'
+    authenticate_url = 'https://api.twitter.com/oauth/authenticate'
 
     def twitter_login(request):
         # Step 1. Get a request token from Twitter.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ can be easily translated to a web application.
 
 # Logging into Django w/ Twitter
 
-Twitter also has the ability to authenticate a user [via an OAuth flow](http://apiwiki.twitter.com/Sign-in-with-Twitter). This
+Twitter also has the ability to authenticate a user [via an OAuth flow](https://dev.twitter.com/docs/auth/sign-twitter). This
 flow is exactly like the three-legged OAuth flow, except you send them to a 
 slightly different URL to authorize them. 
 


### PR DESCRIPTION
The URLs for the twitter examples in the README no longer work, so this change updates them.  I've verified the new example for the CLI personally, but haven't for twitter sign in (the changes do match Twitter's documentation, though). 