### PR TITLE
Make the timestamp more robust against value format

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -769,8 +769,8 @@ class Server(object):
 
     def _check_timestamp(self, timestamp):
         """Verify that timestamp is recentish."""
-        timestamp = int(timestamp)
-        now = int(time.time())
+        timestamp = float(timestamp)
+        now = time.time()
         lapsed = now - timestamp
         if lapsed > self.timestamp_threshold:
             raise Error('Expired timestamp: given %d and now %s has a '


### PR DESCRIPTION
Summary:
Use float instead of int to make timestamp be more robust. Below
shows ValueError when the client sends in a float number

>>> int('183488343.3438394')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: invalid literal for int() with base 10: '183488343.3438394'