### PR TITLE
Client constructor accepts httplib2 options as kwargs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.py?
 *.egg-info
 *.swp
+.cache

--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -615,8 +615,7 @@ class Request(dict):
 class Client(httplib2.Http):
     """OAuthClient is a worker to attempt to execute a request."""
 
-    def __init__(self, consumer, token=None, cache=None, timeout=None,
-        proxy_info=None):
+    def __init__(self, consumer, token=None, **httpOpts):
 
         if consumer is not None and not isinstance(consumer, Consumer):
             raise ValueError("Invalid consumer.")
@@ -628,7 +627,7 @@ class Client(httplib2.Http):
         self.token = token
         self.method = SignatureMethod_HMAC_SHA1()
 
-        httplib2.Http.__init__(self, cache=cache, timeout=timeout, proxy_info=proxy_info)
+        httplib2.Http.__init__(self, **httpOpts)
 
     def set_signature_method(self, method):
         if not isinstance(method, SignatureMethod):

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1193,6 +1193,12 @@ class TestClient(unittest.TestCase):
         except ValueError:
             pass
 
+        # httplib2 options
+        client = oauth.Client(consumer, None, cache='.cache', timeout=3,
+            disable_ssl_certificate_validation=True)
+        self.assertNotEquals(client.cache, None)
+        self.assertEquals(client.timeout, 3)
+
     def test_access_token_get(self):
         """Test getting an access token via GET."""
         client = oauth.Client(self.consumer, None)


### PR DESCRIPTION
Consider using kwargs in the Client constructor, I think it's more compact and flexible.

For example, passing additional HTTP options through the constructor:
```python
client = oauth.Client(consumer, token, timeout=3,
  disable_ssl_certificate_validation=True) 
```
