### PR TITLE
Specification improvement and bug fix to sign_request

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -485,8 +485,14 @@ class Request(dict):
         """Set the signature parameter to the result of sign."""
 
         if not self.is_form_encoded:
-            # according to
+            # according to 
             # http://oauth.googlecode.com/svn/spec/ext/body_hash/1.0/oauth-bodyhash.html
+            # section 3.2 "If the request does not have an entity body, the hash should 
+            # be taken over the empty string."
+            if self.body is None:
+                self.body = ""
+            
+            # according to ibid
             # section 4.1.1 "OAuth Consumers MUST NOT include an
             # oauth_body_hash parameter on requests with form-encoded
             # request bodies."


### PR DESCRIPTION
Per the [OAuth Body Hash specifications](http://oauth.googlecode.com/svn/spec/ext/body_hash/1.0/oauth-bodyhash.html) (3.2), if there is no body entity, then the hash should be done over the empty string.  
  
Also, when `httplib2` handles a redirect, the follow is performed with `None` as the request body. This causes a TypeError to be thrown here when attempting to hash the body.  
  
This commit prevents the TypeError, while improving the specification alignment. 
"Win, win, win." -Michael Scott

-----
Should fix issue #112
Should close pull #113  
  
Many thanks to @holm!