### PR TITLE
Properly identify the Authorization header's Realm part.

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -593,7 +593,7 @@ class Request(dict):
         parts = header.split(',')
         for param in parts:
             # Ignore realm parameter.
-            if param.find('realm') > -1:
+            if param.lower().startswith('realm='):
                 continue
             # Remove whitespace.
             param = param.strip()


### PR DESCRIPTION
This broke authentication whenever any of the `oauth_` parameters contained the substring "realm" anywhere.
