### PR TITLE
amended Client class to pass **kwargs on to super

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -615,8 +615,7 @@ class Request(dict):
 class Client(httplib2.Http):
     """OAuthClient is a worker to attempt to execute a request."""
 
-    def __init__(self, consumer, token=None, cache=None, timeout=None,
-        proxy_info=None):
+    def __init__(self, consumer, token=None, **kwargs):
 
         if consumer is not None and not isinstance(consumer, Consumer):
             raise ValueError("Invalid consumer.")
@@ -628,7 +627,7 @@ class Client(httplib2.Http):
         self.token = token
         self.method = SignatureMethod_HMAC_SHA1()
 
-        httplib2.Http.__init__(self, cache=cache, timeout=timeout, proxy_info=proxy_info)
+        super(Client, self).__init__(**kwargs)
 
     def set_signature_method(self, method):
         if not isinstance(method, SignatureMethod):


### PR DESCRIPTION
Allows more flexibility when instantiating a Client in passing arguments to the super httplib2.Http init. Using in my case because the remote server (flickr) has incorrectly configured SSL certificates, but could be general-purpose useful.