### PR TITLE
Make check for Authorization header more robust.

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -519,10 +519,15 @@ class Request(dict):
             parameters = {}
  
         # Headers
-        if headers and 'Authorization' in headers:
-            auth_header = headers['Authorization']
+        if headers:
+            auth_header = None
+            for k, v in headers.items():
+                if k.lower() == 'authorization' or \
+                    k.upper() == 'HTTP_AUTHORIZATION':
+                    auth_header = v
+
             # Check that the authorization header is OAuth.
-            if auth_header[:6] == 'OAuth ':
+            if auth_header and auth_header[:6] == 'OAuth ':
                 auth_header = auth_header[6:]
                 try:
                     # Get the parameters from the header.

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -914,6 +914,63 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
         req.sign_request(oauth.SignatureMethod_HMAC_SHA1(), con, tok)
         self.assertEquals(req['oauth_signature'], 'IBw5mfvoCsDjgpcsVKbyvsDqQaU=')
 
+
+    def test_from_request_works_with_wsgi(self):
+        """Make sure WSGI header HTTP_AUTHORIZATION is detected correctly."""
+        url = "http://sp.example.com/"
+
+        params = {
+            'oauth_version': "1.0",
+            'oauth_nonce': "4572616e48616d6d65724c61686176",
+            'oauth_timestamp': "137131200",
+            'oauth_consumer_key': "0685bd9184jfhq22",
+            'oauth_signature_method': "HMAC-SHA1",
+            'oauth_token': "ad180jjd733klru7",
+            'oauth_signature': "wOJIO9A2W5mFwDgiDvZbTSMK%2FPY%3D",
+        }
+
+        req = oauth.Request("GET", url, params)
+        headers = req.to_header()
+
+        # Munge the headers
+        headers['HTTP_AUTHORIZATION'] = headers['Authorization']
+        del headers['Authorization'] 
+
+        # Test from the headers
+        req = oauth.Request.from_request("GET", url, headers)
+        self.assertEquals(req.method, "GET")
+        self.assertEquals(req.url, url)
+        self.assertEquals(params, req.copy())
+
+
+    def test_from_request_is_case_insensitive_checking_for_auth(self):
+        """Checks for the Authorization header should be case insensitive."""
+        url = "http://sp.example.com/"
+
+        params = {
+            'oauth_version': "1.0",
+            'oauth_nonce': "4572616e48616d6d65724c61686176",
+            'oauth_timestamp': "137131200",
+            'oauth_consumer_key': "0685bd9184jfhq22",
+            'oauth_signature_method': "HMAC-SHA1",
+            'oauth_token': "ad180jjd733klru7",
+            'oauth_signature': "wOJIO9A2W5mFwDgiDvZbTSMK%2FPY%3D",
+        }
+
+        req = oauth.Request("GET", url, params)
+        headers = req.to_header()
+
+        # Munge the headers
+        headers['authorization'] = headers['Authorization']
+        del headers['Authorization'] 
+
+        # Test from the headers
+        req = oauth.Request.from_request("GET", url, headers)
+        self.assertEquals(req.method, "GET")
+        self.assertEquals(req.url, url)
+        self.assertEquals(params, req.copy())
+
+
     def test_from_request(self):
         url = "http://sp.example.com/"
 


### PR DESCRIPTION
Addresses the following issues:

* #77
* #68 

The check for `Authorization` is now case insensitive and the library also checks for `HTTP_AUTHORIZATION` so you can pass WSGI headers directly.

Here are the tests _without_ the patch applied:

```
(python-oauth2)Joes-MacBook:python-oauth2 jstump$ py.test
====================================================================== test session starts ======================================================================
platform darwin -- Python 2.7.6 -- py-1.4.30 -- pytest-2.7.2
rootdir: /Users/jstump/Dropbox/jstump/dev/python-oauth2, inifile: 
collected 72 items 

tests/test_oauth.py .......................FF...............................................

=========================================================================== FAILURES ============================================================================
______________________________________________ TestRequest.test_from_request_is_case_insensitive_checking_for_auth ______________________________________________

self = <tests.test_oauth.TestRequest testMethod=test_from_request_is_case_insensitive_checking_for_auth>

    def test_from_request_is_case_insensitive_checking_for_auth(self):
        """Checks for the Authorization header should be case insensitive."""
        url = "http://sp.example.com/"
    
        params = {
            'oauth_version': "1.0",
            'oauth_nonce': "4572616e48616d6d65724c61686176",
            'oauth_timestamp': "137131200",
            'oauth_consumer_key': "0685bd9184jfhq22",
            'oauth_signature_method': "HMAC-SHA1",
            'oauth_token': "ad180jjd733klru7",
            'oauth_signature': "wOJIO9A2W5mFwDgiDvZbTSMK%2FPY%3D",
        }
    
        req = oauth.Request("GET", url, params)
        headers = req.to_header()
    
        # Munge the headers
        headers['authorization'] = headers['Authorization']
        del headers['Authorization']
    
        # Test from the headers
        req = oauth.Request.from_request("GET", url, headers)
>       self.assertEquals(req.method, "GET")
E       AttributeError: 'NoneType' object has no attribute 'method'

tests/test_oauth.py:969: AttributeError
_________________________________________________________ TestRequest.test_from_request_works_with_wsgi _________________________________________________________

self = <tests.test_oauth.TestRequest testMethod=test_from_request_works_with_wsgi>

    def test_from_request_works_with_wsgi(self):
        """Make sure WSGI header HTTP_AUTHORIZATION is detected correctly."""
        url = "http://sp.example.com/"
    
        params = {
            'oauth_version': "1.0",
            'oauth_nonce': "4572616e48616d6d65724c61686176",
            'oauth_timestamp': "137131200",
            'oauth_consumer_key': "0685bd9184jfhq22",
            'oauth_signature_method': "HMAC-SHA1",
            'oauth_token': "ad180jjd733klru7",
            'oauth_signature': "wOJIO9A2W5mFwDgiDvZbTSMK%2FPY%3D",
        }
    
        req = oauth.Request("GET", url, params)
        headers = req.to_header()
    
        # Munge the headers
        headers['HTTP_AUTHORIZATION'] = headers['Authorization']
        del headers['Authorization']
    
        # Test from the headers
        req = oauth.Request.from_request("GET", url, headers)
>       self.assertEquals(req.method, "GET")
E       AttributeError: 'NoneType' object has no attribute 'method'

tests/test_oauth.py:941: AttributeError
============================================================== 2 failed, 70 passed in 3.20 seconds ==============================================================
```