### PR TITLE
Update README to only support Python 2.5+

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 This code was originally forked from [Leah Culver and Andy Smith's oauth.py code](http://github.com/leah/python-oauth/). Some of the tests come from a [fork by Vic Fryzel](http://github.com/shellsage/python-oauth), while a revamped Request class and more tests were merged in from [Mark Paschal's fork](http://github.com/markpasc/python-oauth). A number of notable differences exist between this code and its forefathers:
 
+* Compatible with Python 2.5+.
 * 100% unit test coverage.
 * The <code>DataStore</code> object has been completely ripped out. While creating unit tests for the library I found several substantial bugs with the implementation and confirmed with Andy Smith that it was never fully baked.
 * Classes are no longer prefixed with <code>OAuth</code>.
 * The <code>Request</code> class now extends from <code>dict</code>.
-* The library is likely no longer compatible with Python 2.3.
 * The <code>Client</code> class works and extends from <code>httplib2</code>. It's a thin wrapper that handles automatically signing any normal HTTP request you might wish to make.
 
 # Signing a Request


### PR DESCRIPTION
As discussed [here](https://github.com/joestump/python-oauth2/issues/54#issuecomment-126008701), there's a discussion to drop support for Python 2.4. 

This pull takes the first step by updating the README.