### PR TITLE
Update support for Python 2.6+

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This code was originally forked from [Leah Culver and Andy Smith's oauth.py code](http://github.com/leah/python-oauth/). Some of the tests come from a [fork by Vic Fryzel](http://github.com/shellsage/python-oauth), while a revamped Request class and more tests were merged in from [Mark Paschal's fork](http://github.com/markpasc/python-oauth). A number of notable differences exist between this code and its forefathers:
 
-* Compatible with Python 2.5+.
+* Compatible with Python 2.6 and up.
 * 100% unit test coverage.
 * The <code>DataStore</code> object has been completely ripped out. While creating unit tests for the library I found several substantial bugs with the implementation and confirmed with Andy Smith that it was never fully baked.
 * Classes are no longer prefixed with <code>OAuth</code>.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 This code was originally forked from [Leah Culver and Andy Smith's oauth.py code](http://github.com/leah/python-oauth/). Some of the tests come from a [fork by Vic Fryzel](http://github.com/shellsage/python-oauth), while a revamped Request class and more tests were merged in from [Mark Paschal's fork](http://github.com/markpasc/python-oauth). A number of notable differences exist between this code and its forefathers:
 
+* Compatible with Python 2.5+.
 * 100% unit test coverage.
 * The <code>DataStore</code> object has been completely ripped out. While creating unit tests for the library I found several substantial bugs with the implementation and confirmed with Andy Smith that it was never fully baked.
 * Classes are no longer prefixed with <code>OAuth</code>.
 * The <code>Request</code> class now extends from <code>dict</code>.
-* The library is likely no longer compatible with Python 2.3.
 * The <code>Client</code> class works and extends from <code>httplib2</code>. It's a thin wrapper that handles automatically signing any normal HTTP request you might wish to make.
 
 # Signing a Request

--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -91,7 +91,7 @@ def to_unicode(s):
             raise TypeError('You are required to pass either unicode or string here, not: %r (%s)' % (type(s), s))
         try:
             s = s.decode('utf-8')
-        except UnicodeDecodeError, le:
+        except UnicodeDecodeError as le:
             raise TypeError('You are required to pass either a unicode object or a utf-8 string here. You passed a Python string object which contained non-utf-8: %r. The UnicodeDecodeError that resulted from attempting to interpret it as utf-8 was: %s' % (s, le,))
     return s
 
@@ -120,7 +120,7 @@ def to_unicode_optional_iterator(x):
 
     try:
         l = list(x)
-    except TypeError, e:
+    except TypeError as e:
         assert 'is not iterable' in str(e)
         return x
     else:
@@ -136,7 +136,7 @@ def to_utf8_optional_iterator(x):
 
     try:
         l = list(x)
-    except TypeError, e:
+    except TypeError as e:
         assert 'is not iterable' in str(e)
         return x
     else:
@@ -449,7 +449,7 @@ class Request(dict):
             else:
                 try:
                     value = list(value)
-                except TypeError, e:
+                except TypeError as e:
                     assert 'is not iterable' in str(e)
                     items.append((to_utf8_if_string(key), to_utf8_if_string(value)))
                 else:

--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -31,19 +31,8 @@ import hmac
 import binascii
 import httplib2
 
-try:
-    from urlparse import parse_qs
-    parse_qs # placate pyflakes
-except ImportError:
-    # fall back for Python 2.5
-    from cgi import parse_qs
-
-try:
-    from hashlib import sha1
-    sha = sha1
-except ImportError:
-    # hashlib was added in Python 2.5
-    import sha
+from urlparse import parse_qs
+from hashlib import sha1 as sha
 
 import _version
 

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -49,19 +49,19 @@ class TestError(unittest.TestCase):
     def test_message(self):
         try:
             raise oauth.Error
-        except oauth.Error, e:
+        except oauth.Error as e:
             self.assertEqual(e.message, 'OAuth error occurred.')
 
         msg = 'OMG THINGS BROKE!!!!'
         try:
             raise oauth.Error(msg)
-        except oauth.Error, e:
+        except oauth.Error as e:
             self.assertEqual(e.message, msg)
 
     def test_str(self):
         try:
             raise oauth.Error
-        except oauth.Error, e:
+        except oauth.Error as e:
             self.assertEquals(str(e), 'OAuth error occurred.')
 
 class TestGenerateFunctions(unittest.TestCase):
@@ -286,7 +286,7 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
             self.fail("AttributeError should have been raised on empty url.")
         except AttributeError:
             pass
-        except Exception, e:
+        except Exception as e:
             self.fail(str(e))
 
     def test_url(self):


### PR DESCRIPTION
As discussed [here](https://github.com/joestump/python-oauth2/issues/54#issuecomment-126008701), there's a discussion to drop support for Python 2.4. 

This pull takes the first step by updating the README, removing pre-2.6 library imports, and 2.6+ style exception syntax.

Moved https://github.com/joestump/python-oauth2/pull/177 to develop branch here.