### PR TITLE
Revert "Add Classifiers to Setup.py"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,12 +37,4 @@ setup(name=PKG,
       keywords="oauth",
       zip_safe = True,
       test_suite="tests",
-      tests_require=['coverage', 'mock'],
-      classifiers=[
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 2 :: Only',
-        'License :: OSI Approved :: MIT License',
-        'Natural Language :: English',
-        'Development Status :: 5 - Production/Stable'
-      ])
+      tests_require=['coverage', 'mock'])


### PR DESCRIPTION
By having merged to master we have to do one of the following:
a) Rebase develop and screw everyone's downstream develop branches; or:
b) Merge master into develop, possibly causing merge conflicts and cause regressions; or:
c) Patch both develop and master with the change, causing a (easier to solve) merge conflict between master and develop when making a release active

My suggestion is that we revert the change, make sure the pull request is made against the develop branch and rebase the release/1.9 branch on top making the chance of regression, and angry downstream contributors very unlikely.