### PR TITLE
Normalizing parameters duplicated in URL query string and POST parameters

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -468,12 +468,20 @@ class Request(dict):
 
         # Include any query string parameters from the provided URL
         query = urlparse(self.url)[4]
-
         url_items = self._split_url_string(query).items()
         url_items = [(to_utf8(k), to_utf8_optional_iterator(v)) for k, v in url_items if k != 'oauth_signature' ]
-        items.extend(url_items)
+        
+        # Merge together URL and POST parameters.
+        # Eliminates parameters duplicated between URL and POST.
+        items_dict = {}
+        for k,v in items:
+            items_dict.setdefault(k, []).append(v)
+        for k,v in url_items:
+            if not (k in items_dict and v in items_dict[k]):
+                items.append((k,v))
 
         items.sort()
+
         encoded_str = urlencode(items, True)
         # Encode signature parameters per Oauth Core 1.0 protocol
         # spec draft 7, section 3.6

--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -470,15 +470,15 @@ class Request(dict):
         query = urlparse(self.url)[4]
         url_items = self._split_url_string(query).items()
         url_items = [(to_utf8(k), to_utf8_optional_iterator(v)) for k, v in url_items if k != 'oauth_signature' ]
-        
+
         # Merge together URL and POST parameters.
         # Eliminates parameters duplicated between URL and POST.
         items_dict = {}
-        for k,v in items:
+        for k, v in items:
             items_dict.setdefault(k, []).append(v)
-        for k,v in url_items:
+        for k, v in url_items:
             if not (k in items_dict and v in items_dict[k]):
-                items.append((k,v))
+                items.append((k, v))
 
         items.sort()
 

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -756,7 +756,7 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
                '&oauth_version=1.0'
                '&oauth_signature=spWLI%2FGQjid7sQVd5%2FarahRxzJg%3D')
 
-        # duplicates the "search" query parameter in the post parameters (same key and value)
+        # duplicates the "search" query parameter
         parameters = {
             "tag": "two",
             "search": "duplicate",

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -744,6 +744,39 @@ class TestRequest(unittest.TestCase, ReallyEqualMixin):
 
         self.assertEqual(expected, res)
 
+    def test_get_normalized_parameters_duplicate_url_and_post_parameters(self):
+        url = ("http://example.com/v2/search/videos"
+               '?oauth_nonce=79815175'
+               '&oauth_timestamp=1295397962'
+               '&oauth_consumer_key=mykey'
+               '&oauth_signature_method=HMAC-SHA1'
+               '&tag=one'
+               '&search=duplicate'
+               '&offset=10'
+               '&oauth_version=1.0'
+               '&oauth_signature=spWLI%2FGQjid7sQVd5%2FarahRxzJg%3D')
+
+        # duplicates the "search" query parameter in the post parameters (same key and value)
+        parameters = {
+            "tag": "two",
+            "search": "duplicate",
+        }
+        req = oauth.Request("POST", url, parameters)
+
+        res = req.get_normalized_parameters()
+
+        expected = ('oauth_consumer_key=mykey'
+                    '&oauth_nonce=79815175'
+                    '&oauth_signature_method=HMAC-SHA1'
+                    '&oauth_timestamp=1295397962'
+                    '&oauth_version=1.0'
+                    '&offset=10'
+                    '&search=duplicate'
+                    '&tag=one'
+                    '&tag=two')
+
+        self.assertEqual(expected, res)
+
     def test_get_normalized_parameters_multiple(self):
         url = "http://example.com/v2/search/videos?oauth_nonce=79815175&oauth_timestamp=1295397962&oauth_consumer_key=mykey&oauth_signature_method=HMAC-SHA1&oauth_version=1.0&offset=10&oauth_signature=spWLI%2FGQjid7sQVd5%2FarahRxzJg%3D&tag=one&tag=two"
 


### PR DESCRIPTION
This PR modifies the merging of POST parameters with URL query parameters in ```get_normalized_parameters()``` so that duplicate parameters (same key/value) are not duplicated in the normalized base string. 

I could not find any guidance on this issue from [RFC 5849](https://tools.ietf.org/html/rfc5849#section-3.4.1.3.2). Thoughts?