### PR TITLE
Make more explicit about lack of OAuth 2.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Join the chat at https://gitter.im/joestump/python-oauth2](https://img.shields.io/badge/gitter-join%20chat-1dce73.svg?style=flat-square)](https://gitter.im/joestump/python-oauth2?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build Status](http://img.shields.io/travis-ci/joestump/python-oauth2.png?branch=master&style=flat-square)](https://travis-ci.org/joestump/python-oauth2) [![Coverage](https://img.shields.io/codecov/c/github/joestump/python-oauth2.svg?style=flat-square)](https://codecov.io/gh/joestump/python-oauth2) ![Number of issues](https://img.shields.io/github/issues/joestump/python-oauth2.svg?style=flat-square) ![Licence MIT](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)
 
+## Note: This library implements OAuth 1.0 and *not OAuth 2.0*. 
+
 # Overview
 python-oauth2 is a python oauth library fully compatible with python versions: 2.6, 2.7, 3.3 and 3.4. This library is depended on by many other downstream packages such as Flask-Oauth.
 


### PR DESCRIPTION
Three separate projects at my company have wasted time attempting to use this library to build an OAuth 2.0 client, simply because it's named "oauth2". Indeed there is an entire [thread](https://github.com/joestump/python-oauth2/issues/83) about this. 

This banner makes it clear to anyone evaluating the library what it does and does not support.