### PR TITLE
Do not install the "tests" package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(name=PKG,
         "Natural Language :: English",
         "License :: OSI Approved :: MIT License"
       ],
-      packages = find_packages(),
+      packages = find_packages(exclude=['tests']),
       install_requires = ['httplib2'],
       license = "MIT License",
       keywords="oauth",


### PR DESCRIPTION
Porting this from the Gentoo package: https://github.com/gentoo/gentoo/blob/68955bd8ecf702521f68813b5ace72a347096df4/dev-python/oauth2/files/1.9.0_p1-exclude-tests.patch