### PR TITLE
Remove coverage from tests requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,4 +51,4 @@ setup(name=PKG,
       keywords="oauth",
       zip_safe = True,
       test_suite="tests",
-      tests_require=['coverage', 'mock'])
+      tests_require=['mock'])


### PR DESCRIPTION
The test suite itself doesn't require coverage, I thought it could be removed from the dependencies.