### PR TITLE
a tiny workaround for httplib2 redirect bug

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -651,6 +651,9 @@ class Client(httplib2.Http):
         redirections=httplib2.DEFAULT_MAX_REDIRECTS, connection_type=None):
         DEFAULT_POST_CONTENT_TYPE = 'application/x-www-form-urlencoded'
 
+        if body is None:
+            body = b''
+
         if not isinstance(headers, dict):
             headers = {}
 


### PR DESCRIPTION
if 'location' header is in response object, http2lib try to redirect and use self.request method with body=None keyword argument; this behavior implies a problem like this - https://github.com/joestump/python-oauth2/issues/203 and etc.