### PR TITLE
update __init__.py

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -490,7 +490,7 @@ class Request(dict):
             # section 4.1.1 "OAuth Consumers MUST NOT include an
             # oauth_body_hash parameter on requests with form-encoded
             # request bodies."
-            self['oauth_body_hash'] = base64.b64encode(sha1(self.body).digest())
+            self['oauth_body_hash'] = base64.b64encode(sha1(str(self.body).encode('utf-8')).digest())
 
         if 'oauth_consumer_key' not in self:
             self['oauth_consumer_key'] = consumer.key


### PR DESCRIPTION
fix bug 
  File "/home/rendiya/Public/pypro/cucakrowo/facebook/venv/lib/python3.5/site-packages/oauth2/__init__.py", line 493, in sign_request
    self['oauth_body_hash'] = base64.b64encode(sha1(str(self.body).decode('utf-8')).digest())
AttributeError: 'str' object has no attribute 'decode'