### PR TITLE
Remove python 3.3, add python 3.5 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
+  - "3.5"
+  - "3.6"
 install:
   - pip install -r requirements.txt
   - pip install codecov pytest-cov


### PR DESCRIPTION
Python 3.3 has reached end of life: https://www.python.org/downloads/release/python-336/