### PR TITLE
Test and fix for issue #207

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -353,6 +353,7 @@ class Request(dict):
             for k, v in parameters.items():
                 k = to_unicode(k)
                 v = to_unicode_optional_iterator(v)
+
                 self[k] = v
         self.body = body
         self.is_form_encoded = is_form_encoded
@@ -540,6 +541,7 @@ class Request(dict):
         # GET or POST query string.
         if query_string:
             query_params = cls._split_url_string(query_string)
+
             parameters.update(query_params)
  
         # URL parameters.
@@ -757,6 +759,8 @@ class Server(object):
         signature = request.get('oauth_signature')
         if signature is None:
             raise MissingSignature('Missing oauth_signature.')
+        if isinstance(signature, str):
+            signature = signature.encode('ascii', 'ignore')
 
         # Validate the signature.
         valid = signature_method.check(request, consumer, token, signature)

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1210,7 +1210,7 @@ class SignatureMethod_Bad(oauth.SignatureMethod):
 
 class TestServer(unittest.TestCase):
     def setUp(self):
-        url = "http://sp.example.com/"
+        self.url = "http://sp.example.com/"
 
         params = {
             'oauth_version': "1.0",
@@ -1227,7 +1227,7 @@ class TestServer(unittest.TestCase):
 
         params['oauth_token'] = self.token.key
         params['oauth_consumer_key'] = self.consumer.key
-        self.request = oauth.Request(method="GET", url=url, parameters=params)
+        self.request = oauth.Request(method="GET", url=self.url, parameters=params)
 
         signature_method = oauth.SignatureMethod_HMAC_SHA1()
         self.request.sign_request(signature_method, self.consumer, self.token)
@@ -1268,6 +1268,18 @@ class TestServer(unittest.TestCase):
         self.assertEqual(parameters['bar'], 'blerg')
         self.assertEqual(parameters['foo'], 59)
         self.assertEqual(parameters['multi'], ['FOO','BAR'])
+
+    def test_verify_request_query_string(self):
+        server = oauth.Server()
+        server.add_signature_method(oauth.SignatureMethod_HMAC_SHA1())
+
+        signature_method = oauth.SignatureMethod_HMAC_SHA1()
+        request2 = oauth.Request.from_request("GET", self.url, query_string=urlencode(dict(self.request)))
+        request2.sign_request(signature_method, self.consumer, self.token)
+        request3 = oauth.Request.from_request("GET", self.url, query_string=urlencode(dict(request2)))        
+
+        parameters = server.verify_request(request3, self.consumer,
+            self.token)
 
     def test_verify_request_missing_signature(self):
         from oauth2 import MissingSignature


### PR DESCRIPTION
Character encoding of query strings in python 3 makes the signature comparison fail. See issue #207.