### PR TITLE
Explicitly convert body to bytes

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -355,6 +355,8 @@ class Request(dict):
                 v = to_unicode_optional_iterator(v)
 
                 self[k] = v
+        if not isinstance(body, bytes):
+            body = body.encode('utf-8')
         self.body = body
         self.is_form_encoded = is_form_encoded
 


### PR DESCRIPTION
Although there is a default for body to be bytes, if
overridden then encode it