### PR TITLE
Explicitly encode XOAuth string

### DIFF
--- a/oauth2/clients/smtp.py
+++ b/oauth2/clients/smtp.py
@@ -38,4 +38,4 @@ class SMTP(smtplib.SMTP):
             raise ValueError("Invalid token.")
 
         self.docmd('AUTH', 'XOAUTH %s' % \
-            base64.b64encode(oauth2.build_xoauth_string(url, consumer, token)))
+            base64.b64encode(oauth2.build_xoauth_string(url, consumer, token).encode()))


### PR DESCRIPTION
Without `encode`ing the string, I get the following error:

  File "/usr/lib/python3.8/site-packages/oauth2/clients/smtp.py", line 41, in authenticate
    base64.b64encode(oauth2.build_xoauth_string(url, consumer, token)))
  File "/usr/lib/python3.8/base64.py", line 58, in b64encode
    encoded = binascii.b2a_base64(s, newline=False)
TypeError: a bytes-like object is required, not 'str'